### PR TITLE
Added a missing dash

### DIFF
--- a/templates/default/mods/alias.conf.erb
+++ b/templates/default/mods/alias.conf.erb
@@ -15,7 +15,7 @@
   Alias /icons/ "<%= node['apache']['icondir'] %>/"
 
   <Directory "<%= node['apache']['icondir'] %>">
-    Options -Indexes MultiViews -FollowSymLinks
+    Options -Indexes -MultiViews -FollowSymLinks
     AllowOverride None
 <% if node['apache']['version'] == "2.4" -%>
     Require all granted


### PR DESCRIPTION
The apache was raising errors on restart on debian jessie.
